### PR TITLE
Fix: ヒーローセクションの上部パディングを縮小

### DIFF
--- a/soku_siryo/assets/css/style.css
+++ b/soku_siryo/assets/css/style.css
@@ -87,7 +87,7 @@
         /* Hero Section */
         .hero {
             background: linear-gradient(135deg, var(--navy) 0%, var(--navy-dark) 100%);
-            padding: 70px 20px 130px; /* slightly reduced top/bottom spacing */
+            padding: 40px 20px 130px; /* slightly reduced top/bottom spacing */
             position: relative;
             overflow: hidden;
         }
@@ -618,7 +618,7 @@
             .mobile-cta { display: block; }
             body { padding-bottom: 80px; }
 
-            .hero { padding: 80px 20px 120px; }
+            .hero { padding: 50px 20px 120px; }
             .hero-container {
                 flex-direction: column;
                 gap: 20px;


### PR DESCRIPTION
`soku_siryo/assets/css/style.css` を変更し、ヒーローセクションの上部パディングを減らしました。

- デスクトップビューの `.hero` の `padding-top` を `70px` から `40px` に変更しました。
- モバイルビュー（`@media (max-width: 768px)`）の `.hero` の `padding-top` を `80px` から `50px` に変更しました。

これにより、ページのファーストビューでより多くのコンテンツが表示されるようになります。