### PR TITLE
fix(build): Repair the build process for the media sub-application

### DIFF
--- a/media/src/main.tsx
+++ b/media/src/main.tsx
@@ -6,7 +6,6 @@ import "./styles/globals.css";
 
 createRoot(document.getElementById("root")!).render(
   <BrowserRouter basename="/media">
-  <BrowserRouter>
     <Routes>
       <Route path="/" element={<App />} />
       <Route path="/articles/:slug" element={<ArticlePage />} />

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "vite build && node scripts/prerender.mjs",
-    "postbuild": "cd media && npm ci && npm run build"
+    "build": "./node_modules/.bin/vite build && node scripts/prerender.mjs",
+    "postbuild": "cd media && npm ci && ../node_modules/.bin/vite build"
   }
 }

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -6,7 +6,7 @@ import path from 'path'
 const routes = ['/', '/about', '/service', '/contact']
 
 // ViteのSSRローダを使う（ビルドは package.json 側で先に実施）
-const vite = await createServer({ server: { middlewareMode: true } })
+const vite = await createServer({ server: { middlewareMode: true, hmr: false } })
 const { render } = await vite.ssrLoadModule('/src/entry-server.tsx')
 
 // dist の index.html をテンプレに使う


### PR DESCRIPTION
The build was failing to correctly integrate the `/media` sub-application due to a combination of issues:

1. A build error in the `prerender.mjs` script caused by the Vite server attempting to open an HMR port in a restricted environment.
2. A JSX syntax error in `media/src/main.tsx` with a duplicate `<BrowserRouter>`.
3. The `vite` command was not always found in the shell path during the build script execution.

This commit resolves these issues by:
- Disabling the HMR server in `prerender.mjs` to prevent build failures.
- Correcting the JSX syntax in `media/src/main.tsx`.
- Updating the `package.json` build scripts to use the full relative path to the Vite executable, ensuring the build runs reliably.

The build process now successfully builds and integrates both the main application and the media sub-application into the `dist` directory.