### PR TITLE
fix(cms-api): Geminiの構成案生成におけるmax_tokensを増やす

### DIFF
--- a/cms-api/src/server.js
+++ b/cms-api/src/server.js
@@ -366,19 +366,19 @@ app.post('/generate-outline', requireAdmin, async (req, res) => {
 
     let json
     try {
-      const firstMax = provider === 'gemini' ? 2048 : 1200
+      const firstMax = provider === 'gemini' ? 4096 : 1200
       json = await llmChatJSON({ provider, system, user, schema, temperature: 0.6, max_tokens: firstMax, model })
     } catch (e) {
       const msg = String(e?.message || '')
       if (provider === 'gemini' && (msg.includes('MAX_TOKENS') || msg.includes('valid JSON'))) {
         const compact = `前提\n- キーワード: ${keyword}\n- カテゴリ: ${category}\n\nJSONのみ返す（短く簡潔に）。キー: title, slug, h2[{title,h3(<=1)}]。h2は最大4個。各文字列は20文字以内。説明やフェンスは禁止。`
         try {
-          json = await llmChatJSON({ provider, system, user: compact, schema: undefined, temperature: 1, max_tokens: 800, model })
+          json = await llmChatJSON({ provider, system, user: compact, schema: undefined, temperature: 1, max_tokens: 2048, model })
         } catch (e2) {
           const msg2 = String(e2?.message || '')
           if (msg2.includes('MAX_TOKENS') || msg2.includes('valid JSON')) {
             const ultra = `JSONのみ返す。キー: title, slug, h2[{title}]。h2は3個。各文字列は16文字以内。説明・余計な文字・フェンス禁止。キーワード:${keyword}`
-            json = await llmChatJSON({ provider, system, user: ultra, schema: undefined, temperature: 1, max_tokens: 400, model })
+            json = await llmChatJSON({ provider, system, user: ultra, schema: undefined, temperature: 1, max_tokens: 1024, model })
           } else {
             throw e2
           }


### PR DESCRIPTION
Geminiを使用した構成案の生成が `MAX_TOKENS` エラーで失敗していました。これは、リトライロジックを含め、`maxOutputTokens` の上限値が低すぎたことが原因でした。

この変更では、`/generate-outline` エンドポイントにおける初回呼び出しおよび後続のリトライ時の `max_tokens` の値を引き上げ、モデルがより長く詳細な応答を返せるようにすることで、エラーの発生を防ぎます。

- 初回呼び出しの `max_tokens` を2048から4096に増加
- 1回目のリトライの `max_tokens` を800から2048に増加
- 2回目のリトライの `max_tokens` を400から1024に増加