### PR TITLE
Fix: Increase max_tokens for keyword planner

### DIFF
--- a/cms-api/src/server.js
+++ b/cms-api/src/server.js
@@ -570,7 +570,7 @@ app.post('/keyword-planner', requireAdmin, async (req, res) => {
     const system = 'あなたは日本語のSEOアナリストです。検索意図を分類し、重複を避けて実務的なキーワード候補を出します。'
     const user = `前提\n- 言語: ${language}\n- 種キーワード: ${seed}\n- テーマ補足: ${theme || 'なし'}\n- 件数目安: ${count}\n\n要件\n- JSONのみ返す（seed, suggestions[]）。\n- suggestions[].intent は Informational / Commercial / Transactional / Navigational のいずれか。\n- volume は相対評価（low/medium/high）。difficulty は1-5（相対難易度）。\n- variations は同義/言い換え、questions はよくある質問（2-4件）。\n- title_idea は記事タイトル案（1つ）。\n- 重複・冗長を避け、ビジネスで使える粒度に。`
 
-    const firstMax = provider === 'gemini' ? 2048 : 1600
+    const firstMax = provider === 'gemini' ? 4096 : 1600
     let json
     try {
       json = await llmChatJSON({ provider, system, user, schema, temperature: 0.7, max_tokens: firstMax, model })
@@ -580,12 +580,12 @@ app.post('/keyword-planner', requireAdmin, async (req, res) => {
         // Compact fallback: reduce fields and count, relax schema
         const compact = `前提\n- 種キーワード: ${seed}\n- 件数: ${Math.min(Number(count)||20, 12)}\n\n出力（JSONのみ）：{"seed":string,"suggestions":[{"keyword":string,"intent":"Informational"|"Commercial"|"Transactional"|"Navigational","volume":string,"difficulty":integer,"title_idea":string}] }\n制約:\n- suggestionsは短く簡潔に（各文字列<=32）。\n- variations/questionsは省略可。説明・フェンス禁止。`
         try {
-          json = await llmChatJSON({ provider, system, user: compact, schema: undefined, temperature: 0.7, max_tokens: 1024, model })
+          json = await llmChatJSON({ provider, system, user: compact, schema: undefined, temperature: 0.7, max_tokens: 2048, model })
         } catch (e2) {
           const msg2 = String(e2?.message || '')
           if (msg2.includes('MAX_TOKENS') || msg2.includes('valid JSON')) {
             const ultra = `JSONのみ返す。キー: seed, suggestions[{keyword,intent}](~8件)。説明・余計な文字・フェンス禁止。seed:${seed}`
-            json = await llmChatJSON({ provider, system, user: ultra, schema: undefined, temperature: 0.7, max_tokens: 600, model })
+            json = await llmChatJSON({ provider, system, user: ultra, schema: undefined, temperature: 0.7, max_tokens: 1024, model })
           } else {
             throw e2
           }


### PR DESCRIPTION
The keyword planner was failing with a `MAX_TOKENS` error because the response from the Gemini API was being truncated.

This change increases the `max_tokens` values for the initial and fallback API calls within the `/keyword-planner` endpoint. This provides more space for the model to generate a complete JSON response, preventing the error.