### PR TITLE
fix(cms-api): Use correct `max_tokens` parameter for OpenAI calls

### DIFF
--- a/cms-api/src/server.js
+++ b/cms-api/src/server.js
@@ -252,7 +252,7 @@ async function openaiChatJSON({ system, user, schema, temperature = 0.7, max_tok
     const rf = schema && useSchema
       ? { type: 'json_schema', json_schema: { name: 'response', schema, strict: true } }
       : { type: 'json_object' }
-    return { ...base, max_completion_tokens: max_tokens, response_format: rf }
+    return { ...base, max_tokens: max_tokens, response_format: rf }
   }
 
   // Try schema first, then fallback


### PR DESCRIPTION
The `openaiChatJSON` function was using `max_completion_tokens` when calling the OpenAI Chat Completions API. This parameter is not correct; the official parameter for controlling the maximum number of tokens in the response is `max_tokens`.

This error likely caused API calls to fail or return truncated responses, which in turn triggered a fallback mechanism in the `normalizeOutlineData` function, causing a static, predefined outline to be displayed to the user instead of a newly generated one.

This change corrects the parameter name to `max_tokens`, which should resolve the API call failures and allow the GPT-based outline generation to work as intended.