### PR TITLE
fix(ci): simplify deploy guard and fix YAML error

### DIFF
--- a/.github/workflows/deploy-media.yml
+++ b/.github/workflows/deploy-media.yml
@@ -1,47 +1,49 @@
 name: Deploy media to Sakura
+
 on:
-  push:
-    branches: [ main ]
-    paths:
-      - 'media/**'
-      - '!media/node_modules/**'
+    push:
+      branches: [ main ]
+      paths:
+        - 'media/**'
+        - '!media/node_modules/**'
+
 jobs:
-  build-and-deploy:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: |
-            media/package-lock.json
-      - name: Build media site
-        working-directory: media
-        env:
-          VITE_CMS_API_BASE: ${{ secrets.VITE_CMS_API_BASE }}
-          VITE_ADMIN_TOKEN: ${{ secrets.VITE_ADMIN_TOKEN }}
-        run: |
-          npm ci
-          npm run build
-          npm run postbuild
-      - name: Skip deploy (secrets not set)
-        if: ${{ !(secrets.SAKURA_HOST != '' && secrets.SAKURA_USER != '' && (secrets.SAKURA_PASSWORD != '' || secrets.SAKURA_SSH_KEY != '') && secrets.SAKURA_REMOTE_DIR != '') }}
-        run: echo "Secrets not set; skipping SFTP deploy."
-      - name: Upload dist/media via SFTP
-        if: ${{ secrets.SAKURA_HOST != '' && secrets.SAKURA_USER != '' && (secrets.SAKURA_PASSWORD != '' || secrets.SAKURA_SSH_KEY != '') && secrets.SAKURA_REMOTE_DIR != '' }}
-        uses: wlixcc/SFTP-Deploy-Action@v1.3.1
-        with:
-          server: ${{ secrets.SAKURA_HOST }}
-          username: ${{ secrets.SAKURA_USER }}
-          password: ${{ secrets.SAKURA_PASSWORD }}
-          # key: ${{ secrets.SAKURA_SSH_KEY }}
-          local_path: media/dist/media
-          remote_path: ${{ secrets.SAKURA_REMOTE_DIR }}
-          sftp_only: true
-          exclude: |
-            **/.git*
-            **/.DS_Store
-            **/*.map
+    build-and-deploy:
+      runs-on: ubuntu-latest
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v4
+
+        - name: Setup Node.js
+          uses: actions/setup-node@v4
+          with:
+            node-version: '20'
+            cache: 'npm'
+            cache-dependency-path: |
+              media/package-lock.json
+
+        - name: Build media site
+          working-directory: media
+          env:
+            VITE_CMS_API_BASE: ${{ secrets.VITE_CMS_API_BASE }}
+            VITE_ADMIN_TOKEN: ${{ secrets.VITE_ADMIN_TOKEN }}
+          run: |
+            npm ci
+            npm run build
+            npm run postbuild
+
+        - name: Upload dist/media via SFTP
+          if: ${{ secrets.SAKURA_HOST != '' && secrets.SAKURA_USER != '' && (secrets.SAKURA_PASSWORD != '' || secrets.SAKURA_SSH_KEY != '') && secrets.SAKURA_REMOTE_DIR != '' }}
+          uses: wlixcc/SFTP-Deploy-Action@v1.3.1
+          with:
+            server: ${{ secrets.SAKURA_HOST }}
+            username: ${{ secrets.SAKURA_USER }}
+            password: ${{ secrets.SAKURA_PASSWORD }}
+            # key: ${{ secrets.SAKURA_SSH_KEY }}   # 鍵認証を使う場合はこちら
+            local_path: media/dist/media
+            remote_path: ${{ secrets.SAKURA_REMOTE_DIR }}
+            sftp_only: true
+            exclude: |
+              **/.git*
+              **/.DS_Store
+              **/*.map


### PR DESCRIPTION
This PR updates the deploy-media.yml workflow to simplify the secrets guard and remove the separate skip-deploy step.

Changes include:
- Remove the "Skip deploy" step that caused YAML parsing errors.
- Keep only the SFTP deploy step, with a single `if` condition that checks all required Sakura secrets.
- Ensure `local_path` is set to `media/dist/media` so dotfiles (like .htaccess) are uploaded.
- Confirm `exclude` patterns include `**/*.map` to avoid uploading source maps.

With these changes, pushes to main will build the media site and, when secrets are configured, automatically upload the build via SFTP. If secrets are missing, the SFTP step will be skipped and the workflow will complete without error.
