### PR TITLE
Fix: Correct deployment workflow and trigger new run

### DIFF
--- a/.github/workflows/deploy-media.yml
+++ b/.github/workflows/deploy-media.yml
@@ -43,7 +43,3 @@ jobs:
             local_path: media/dist/media
             remote_path: ${{ secrets.SAKURA_REMOTE_DIR }}
             sftp_only: true
-            exclude: |
-              **/.git*
-              **/.DS_Store
-              **/*.map

--- a/media/README.md
+++ b/media/README.md
@@ -14,4 +14,5 @@
   - Env: `VITE_CMS_API_BASE` (CMS API URL), `VITE_ADMIN_TOKEN`
   - Features: AI outline generation and article drafting (requires CMS API with `OPENAI_API_KEY` or `GEMINI_API_KEY`).
   - Provider select: Default is `Gemini (gemini-2.5-pro)`. You can switch to `GPT-5 (OpenAI)` or override the model ID per request.
-  
+
+<!-- Trigger deployment -->

--- a/media/README.md
+++ b/media/README.md
@@ -1,4 +1,3 @@
-
 # AI Marketing News
 
 マーケティングの最新ニュースと実務知見を届けるメディアです。SEO、広告、コンテンツ、SNS、CRM/MA、マーケティングAI活用までをカバーします。
@@ -15,4 +14,4 @@
   - Features: AI outline generation and article drafting (requires CMS API with `OPENAI_API_KEY` or `GEMINI_API_KEY`).
   - Provider select: Default is `Gemini (gemini-2.5-pro)`. You can switch to `GPT-5 (OpenAI)` or override the model ID per request.
 
-<!-- Trigger deployment -->
+<!-- Resolved deployment trigger -->


### PR DESCRIPTION
This commit addresses a failing GitHub Actions workflow for deploying to Sakura Server.

The `deploy-media.yml` workflow was failing due to an invalid `exclude` parameter in the SFTP action step. This parameter is not supported by the `wlixcc/SFTP-Deploy-Action@v1.3.1` action when `sftp_only` is true. The parameter has been removed to fix the workflow.

Additionally, a comment has been added to `media/README.md` to trigger a new run of the corrected workflow.