### PR TITLE
Adjust article generator defaults for neutral topics

### DIFF
--- a/cms-api/src/server.js
+++ b/cms-api/src/server.js
@@ -289,6 +289,89 @@ app.post('/extract-headings', async (req, res) => {
   }
 })
 
+app.post('/analyze-serp', requireAdmin, async (req, res) => {
+  try {
+    const { provider = 'gemini', model } = req.body || {}
+    if (provider === 'gemini') { if (!ensureGemini(res)) return } else { if (!ensureOpenAI(res)) return }
+    const keyword = String(req.body?.keyword || '').trim()
+    if (!keyword) return res.status(400).json({ error: 'keyword is required' })
+    const rawSources = Array.isArray(req.body?.sources) ? req.body.sources : []
+    if (!rawSources.length) return res.status(400).json({ error: 'sources are required' })
+
+    const sourcesText = rawSources.slice(0, 6).map((s, idx) => {
+      const title = typeof s?.title === 'string' ? s.title : ''
+      const url = typeof s?.url === 'string' ? s.url : ''
+      const h2 = Array.isArray(s?.headings?.h2) ? s.headings.h2.slice(0, 6).map((v) => `- ${String(v).slice(0, 60)}`).join('\n') : ''
+      const h3 = Array.isArray(s?.headings?.h3) ? s.headings.h3.slice(0, 4).map((v) => `- ${String(v).slice(0, 60)}`).join('\n') : ''
+      return `#${idx + 1} ${title || url}\nURL: ${url}\n主なH2:\n${h2 || '-'}\n主なH3:\n${h3 || '-'}`
+    }).join('\n\n')
+
+    const schema = {
+      type: 'object',
+      required: ['intent_label', 'intent_summary', 'persona', 'article_direction', 'user_needs', 'solution'],
+      additionalProperties: false,
+      properties: {
+        intent_label: { type: 'string', enum: ['Do', 'Know', 'Buy', 'Go'] },
+        intent_summary: { type: 'string' },
+        persona: { type: 'string' },
+        article_direction: { type: 'string' },
+        user_needs: { type: 'array', items: { type: 'string' }, minItems: 1 },
+        solution: { type: 'string' },
+        notes: { type: 'string' }
+      }
+    }
+
+    const system = 'あなたは日本語のSEOコンテンツストラテジストです。検索結果を精査し、読者インサイトと記事の狙いを短く整理します。冗長な言い回しは避け、実務的かつ端的にまとめてください。'
+    const user = `前提\n- キーワード: ${keyword}\n- 参照した検索結果:\n${sourcesText || '-'}\n\nタスク\n1. 検索意図を Do / Know / Buy / Go のいずれかで分類し、根拠を1〜2文で整理する。\n2. 想定ペルソナ（立場・役割・課題感）を一文でまとめる。\n3. 記事の方向性（狙う切り口・ゴール）を具体的に示す。\n4. ペルソナが抱える主要ニーズを3つ前後の箇条書きで整理する。\n5. そのニーズを満たすための解決方針を一段落で説明する。\n必要ならnotesにメモを追加してよい。\n\n出力形式（JSONのみ）:\n{"intent_label":"Do|Know|Buy|Go","intent_summary":"根拠","persona":"一文","article_direction":"一文","user_needs":["ニーズ1","ニーズ2"],"solution":"解決策","notes":"任意"}\n制約:\n- すべて日本語。\n- 箇条書きは簡潔に。\n- JSON以外の文字列・コードフェンスは禁止。`
+
+    const maxTokens = provider === 'gemini' ? 3072 : 2048
+    let json
+    try {
+      json = await llmChatJSON({ provider, system, user, schema, temperature: 0.4, max_tokens: maxTokens, model })
+    } catch (e) {
+      throw e
+    }
+
+    const clamp = (value, max) => {
+      const str = typeof value === 'string' ? value.trim() : ''
+      if (!str) return ''
+      return str.length > max ? str.slice(0, max) : str
+    }
+    const allowed = new Set(['Do', 'Know', 'Buy', 'Go'])
+    let intentLabel = clamp(json?.intent_label, 10)
+    if (!allowed.has(intentLabel)) intentLabel = 'Know'
+    const persona = clamp(json?.persona, 160)
+    const direction = clamp(json?.article_direction, 220)
+    const summary = clamp(json?.intent_summary, 220)
+    const solution = clamp(json?.solution, 260)
+    const notes = clamp(json?.notes, 260)
+    const needs = Array.isArray(json?.user_needs)
+      ? json.user_needs.map((v) => clamp(v, 120)).filter(Boolean)
+      : []
+
+    const defaultPersona = keyword ? `${keyword}に関心のある人` : 'このテーマに関心のある人'
+    const defaultNeeds = keyword ? [`${keyword}の基本や活用方法を知りたい`] : ['テーマの基本を理解したい']
+    const defaultSolution = keyword
+      ? `${keyword}に関する主要な疑問へ体系的に答えるコンテンツを用意する`
+      : '主要な疑問に順番に答える構成にする'
+    const defaultDirection = '検索意図に沿って読者の疑問を順番に解消する構成にする'
+    const analysis = {
+      intent_label: intentLabel,
+      intent_summary: summary,
+      persona: persona || defaultPersona,
+      article_direction: direction || defaultDirection,
+      user_needs: needs.length ? needs : defaultNeeds,
+      solution: solution || defaultSolution,
+      notes: notes || undefined,
+    }
+
+    res.json({ ok: true, analysis })
+  } catch (e) {
+    console.error('analyze-serp error:', e?.message || e)
+    res.status(500).json({ error: 'Failed to analyze SERP', detail: String(e?.message || '') })
+  }
+})
+
 // --- LLM helpers ---
 function ensureOpenAI(res) {
   if (!OPENAI_API_KEY) {
@@ -452,11 +535,13 @@ async function llmChatJSON({ provider = 'openai', ...opts }) {
 // slugify is defined above (shared helpers)
 
 function normalizeOutlineData(input, { keyword, category, tone, target_audience, word_count_target }) {
-  const title = String(input?.title || keyword || '').slice(0, 160) || `${keyword}のガイド`
+  const keywordText = String(keyword || '').trim()
+  const title = String(input?.title || keywordText || '').slice(0, 160) || `${keywordText}のガイド`
   const slug = slugify(input?.slug || title)
-  const persona = input?.persona || 'マーケター'
+  const defaultPersona = keywordText ? `${keywordText}に関心のある人` : 'このテーマに関心のある人'
+  const persona = input?.persona || defaultPersona
   const seo = input?.seo && typeof input.seo === 'object' ? input.seo : {}
-  const ta = input?.target_audience || target_audience
+  const ta = input?.target_audience || target_audience || defaultPersona
   const tn = input?.tone || tone
   const wc = Number(input?.word_count_target || word_count_target)
 
@@ -483,14 +568,15 @@ function normalizeOutlineData(input, { keyword, category, tone, target_audience,
   }
 
   if (!h2 || h2.length === 0) {
+    const theme = keywordText || 'テーマ'
     h2 = [
-      { title: 'イントロダクション', h3: [] },
-      { title: `${keyword}の基礎`, h3: ['定義', '重要性', '適用領域'] },
-      { title: `${keyword}の実務活用`, h3: ['手順', 'テンプレート', 'チェックリスト'] },
-      { title: '成功事例とベストプラクティス', h3: [] },
-      { title: '計測とKPI設定', h3: ['指標', 'レポート例'] },
-      { title: 'よくある落とし穴と対策', h3: [] },
-      { title: 'まとめ・次のアクション', h3: [] },
+      { title: `${theme}とは`, h3: ['背景', '基本の考え方'] },
+      { title: `${theme}の特徴とメリット`, h3: ['メリット', '注意点'] },
+      { title: `${theme}の始め方`, h3: ['準備', '手順', 'チェックポイント'] },
+      { title: `${theme}の活用シーン`, h3: ['活用例', '参考になる取り組み'] },
+      { title: `${theme}をより良くするヒント`, h3: ['コツ', 'よくある課題と対策'] },
+      { title: `${theme}に関するよくある質問`, h3: [] },
+      { title: 'まとめ', h3: ['押さえておきたいポイント', '次のステップ'] },
     ]
   }
 
@@ -516,12 +602,44 @@ app.post('/generate-outline', requireAdmin, async (req, res) => {
     const {
       keyword,
       category = '',
-      tone = '実務的で明快',
-      target_audience = 'マーケ担当者・事業責任者',
+      tone = 'わかりやすく丁寧',
+      target_audience = 'このテーマに関心のある人',
       word_count_target = 1800,
     } = req.body || {}
     if (!keyword || typeof keyword !== 'string') {
       return res.status(400).json({ error: 'keyword is required' })
+    }
+
+    const clamp = (value, max) => {
+      const str = typeof value === 'string' ? value.trim() : ''
+      if (!str) return ''
+      return str.length > max ? str.slice(0, max) : str
+    }
+
+    const analysisInput = req.body?.analysis && typeof req.body.analysis === 'object' ? req.body.analysis : null
+    const allowedIntent = new Set(['Do', 'Know', 'Buy', 'Go'])
+    let analysisBlock = ''
+    let analysisPersona = ''
+    if (analysisInput) {
+      const intentLabel = clamp(analysisInput.intent_label, 10)
+      const safeIntent = allowedIntent.has(intentLabel) ? intentLabel : ''
+      const intentSummary = clamp(analysisInput.intent_summary, 200)
+      const persona = clamp(analysisInput.persona, 160)
+      const direction = clamp(analysisInput.article_direction, 220)
+      const needs = Array.isArray(analysisInput.user_needs)
+        ? analysisInput.user_needs.map((v) => clamp(v, 120)).filter(Boolean)
+        : []
+      const solution = clamp(analysisInput.solution, 220)
+      const notes = clamp(analysisInput.notes, 200)
+      const lines = []
+      if (safeIntent) lines.push(`検索意図: ${safeIntent}${intentSummary ? `（${intentSummary}）` : ''}`)
+      if (persona) lines.push(`想定ペルソナ: ${persona}`)
+      if (direction) lines.push(`記事の方向性: ${direction}`)
+      if (needs.length) lines.push(`主要ニーズ:\n${needs.map((n) => `  - ${n}`).join('\n')}`)
+      if (solution) lines.push(`ニーズ解決策: ${solution}`)
+      if (notes) lines.push(`補足: ${notes}`)
+      analysisBlock = lines.length ? `\n- 検索意図・ニーズ分析:\n${lines.join('\n')}` : ''
+      analysisPersona = persona
     }
 
     const schema = {
@@ -570,8 +688,8 @@ app.post('/generate-outline', requireAdmin, async (req, res) => {
     }).join('\\n\\n')
     const refBlock = sourcesText ? `\n\n参考サイトの見出しを参考に、重複・コピペを避けて最適な構成を作ること:\n${sourcesText}` : ''
 
-    const userOpenAI = `前提\n- キーワード: ${keyword}\n- トーン: ${tone}\n- 想定読者: ${target_audience}\n- 目標文字数: ${word_count_target}${refBlock}\n\n出力形式（JSONのみ）：\n{"title":string,"slug":string,"persona":string,"target_audience":string,"tone":string,"word_count_target":number,"seo":{"keywords":string[],"meta_description":string,"cta":string},"h2":[{"title":"章タイトル","h3":["小見出し1", "小見出し2", "..."]}] }\n\n注意:\n- h3の数は章の内容に応じて柔軟に増減させてください。例えば、h3が0個や5個以上になることもあります。\n- JSON以外のテキスト（説明、注釈、コードフェンスなど）は絶対に出力しないでください。`
-    const userGemini = `前提\n- キーワード: ${keyword}\n- トーン: ${tone}\n- 想定読者: ${target_audience}\n- 目標文字数: ${word_count_target}${refBlock}\n\n出力形式（JSONのみ）：\n{"title":string,"slug":string,"persona":string,"target_audience":string,"tone":string,"word_count_target":number,"seo":{"keywords":string[],"meta_description":string,"cta":string},"h2":[{"title":"章タイトル","h3":["小見出し1", "小見出し2", "..."]}] }\n注意:\n- 各h2見出しに含めるh3見出しの数は、内容の複雑さに応じて調整してください。h3が不要な場合もあれば、多数必要な場合もあります。\n- 説明文やコードフェンスは禁止。JSON以外の出力は禁止。`
+    const userOpenAI = `前提\n- キーワード: ${keyword}\n- トーン: ${tone}\n- 想定読者: ${target_audience}\n- 目標文字数: ${word_count_target}${analysisBlock}${refBlock}\n\n出力形式（JSONのみ）：\n{"title":string,"slug":string,"persona":string,"target_audience":string,"tone":string,"word_count_target":number,"seo":{"keywords":string[],"meta_description":string,"cta":string},"h2":[{"title":"章タイトル","h3":["小見出し1", "小見出し2", "..."]}] }\n\n注意:\n- h3の数は章の内容に応じて柔軟に増減させてください。例えば、h3が0個や5個以上になることもあります。\n- JSON以外のテキスト（説明、注釈、コードフェンスなど）は絶対に出力しないでください。`
+    const userGemini = `前提\n- キーワード: ${keyword}\n- トーン: ${tone}\n- 想定読者: ${target_audience}\n- 目標文字数: ${word_count_target}${analysisBlock}${refBlock}\n\n出力形式（JSONのみ）：\n{"title":string,"slug":string,"persona":string,"target_audience":string,"tone":string,"word_count_target":number,"seo":{"keywords":string[],"meta_description":string,"cta":string},"h2":[{"title":"章タイトル","h3":["小見出し1", "小見出し2", "..."]}] }\n注意:\n- 各h2見出しに含めるh3見出しの数は、内容の複雑さに応じて調整してください。h3が不要な場合もあれば、多数必要な場合もあります。\n- 説明文やコードフェンスは禁止。JSON以外の出力は禁止。`
     const user = provider === 'gemini' ? userGemini : userOpenAI
 
     let json
@@ -598,6 +716,12 @@ app.post('/generate-outline', requireAdmin, async (req, res) => {
       }
     }
     const outline = normalizeOutlineData(json, { keyword, category, tone, target_audience, word_count_target })
+    if (analysisPersona && (!outline.persona || !String(outline.persona).trim())) {
+      outline.persona = analysisPersona
+    }
+    if (analysisPersona && (!outline.target_audience || !String(outline.target_audience).trim())) {
+      outline.target_audience = analysisPersona
+    }
     res.json({ ok: true, outline })
   } catch (e) {
     console.error('generate-outline error:', e?.message || e)
@@ -647,13 +771,13 @@ app.post('/generate-article', requireAdmin, async (req, res) => {
       return `${i + 1}. ${sec.title}${h3 ? `\n${h3}` : ''}`
     }).join('\n')
 
-    const system = 'あなたは日本語のプロ編集者・ライターです。専門的で実務に役立つ記事を、検証可能な情報と具体例で執筆します。冗長・誇張を避け、段落中心で読みやすいHTML構造に整えます。'
+    const system = 'あなたは日本語のプロ編集者・ライターです。専門的なテーマでも読み手が理解しやすいよう構成と文章を整えます。冗長・誇張を避け、段落中心で読みやすいHTML構造にまとめてください。'
     const exampleArticle = {
-      title: 'B2BのSEOで成果を出すコンテンツ戦略ガイド',
-      excerpt: 'B2B企業がパイプラインを伸ばすためのSEO/コンテンツ戦略。検索意図、トピッククラスター、E-E-A-T、計測まで実務視点で解説。',
-      body: '<p>本稿では、B2Bで成果に直結するSEOの考え方と実装手順を解説します。まず全体像を掴み、次に実務で使える型へ落とし込みます。</p>\n<h2>検索意図の分解と優先順位付け</h2>\n<p>まず重要なのは、見込み顧客の文脈に沿って検索意図を分解することです。単語ではなく課題の表現として捉え、業界・職種・熟達度で粒度を合わせます。</p>\n<p>意図ごとに必要なコンテンツの役割は異なります。情報収集段階では用語の定義や判断基準、比較検討では差異化ポイントや導入条件が響きます。</p>\n<h3>意図分類の実務メモ</h3>\n<p>現場では、検索クエリの原文をそのままグルーピングするより、営業やCSの会話ログと突き合わせて課題表現に変換すると精度が上がります。</p>\n<ul><li>情報（課題理解）：定義、背景、判断軸</li><li>比較（解決策検討）：差異化、適用条件</li><li>取引（意思決定）：要件、導入プロセス</li></ul>\n<h2>まとめ・次のアクション</h2>\n<p>小さく検証し、勝ち筋の型をテンプレート化して横展開します。効果測定はリードの質と商談化率で確認します。</p>'
+      title: '家庭で備える防災対策ガイド',
+      excerpt: '家庭で実践できる防災対策をまとめたガイド。日頃の備えから避難時の行動まで、家族で共有したいポイントを整理します。',
+      body: '<p>この記事では、家庭で備えておきたい防災対策を整理します。日頃の準備と緊急時の行動を分けて確認し、家族で共有できる形にまとめましょう。</p>\n<h2>日頃から整えておく備え</h2>\n<p>飲料水や非常食、常備薬などの備蓄は家族の人数とライフスタイルに合わせて用意します。</p>\n<p>懐中電灯やモバイルバッテリー、防災ラジオなどは定期的に点検し、いざという時に使える状態を維持しましょう。</p>\n<h2>避難時に意識したい行動</h2>\n<p>自宅や職場周辺のハザードマップを確認し、避難経路や集合場所を事前に決めておきます。</p>\n<p>災害発生時は最新情報をこまめに確認し、安全を最優先に落ち着いて行動することが大切です。</p>'
     }
-    const user = `前提:\n- サイト: AIMA（AIマーケティング）\n- トーン: ${outline.tone || '実務的で明快'}\n- 想定読者: ${outline.target_audience || 'マーケ担当者'}\n- 目標文字数: 約${targetWords}文字\n- 見出し構成:\n${outlineText}\n\n出力要件:\n- JSONのみ返す（title, excerpt, body）。前後の説明やコードフェンスは不要。\n- bodyはHTMLで、<h2>/<h3>/<p>/<ul>/<li>のみ使用。<p>を主体に、各セクションは段落から始める。\n- 箇条書きは必要な場合のみ。各<h2>セクションで<ul>は最大1回、3〜5項目まで。連続した<ul>は禁止。\n- 各<h2>は少なくとも2つの<p>を含む。各<h3>も少なくとも1つの<p>を含む。\n- 導入で期待値を提示し、各見出しでは段落で解説→必要なら要点を<ul>で補足。最後はまとめの段落で締める。\n- 根拠のない断定や最新情報の言い切りは避ける。`
+    const user = `前提:\n- サイト: AIMA（AIとマーケティングの知見を扱うメディア）\n- トーン: ${outline.tone || 'わかりやすく丁寧'}\n- 想定読者: ${outline.target_audience || 'このテーマに関心のある人'}\n- 目標文字数: 約${targetWords}文字\n- 見出し構成:\n${outlineText}\n\n出力要件:\n- JSONのみ返す（title, excerpt, body）。前後の説明やコードフェンスは不要。\n- bodyはHTMLで、<h2>/<h3>/<p>/<ul>/<li>のみ使用。<p>を主体に、各セクションは段落から始める。\n- 箇条書きは必要な場合のみ。各<h2>セクションで<ul>は最大1回、3〜5項目まで。連続した<ul>は禁止。\n- 各<h2>は少なくとも2つの<p>を含む。各<h3>も少なくとも1つの<p>を含む。\n- 導入で期待値を提示し、各見出しでは段落で解説→必要なら要点を<ul>で補足。最後はまとめの段落で締める。\n- 根拠のない断定や最新情報の言い切りは避ける。`
 
     let json = await llmChatJSON({ provider, system, user, schema, temperature: 0.7, max_tokens: 16384, model })
 

--- a/media/src/pages/ToolsArticle.tsx
+++ b/media/src/pages/ToolsArticle.tsx
@@ -26,6 +26,18 @@ type Outline = {
 type SourceHeadings = { h1?: string[]; h2?: string[]; h3?: string[]; h4?: string[] }
 type SourceResult = { url: string; title: string; headings: SourceHeadings }
 
+type IntentLabel = 'Do' | 'Know' | 'Buy' | 'Go'
+
+type SerpAnalysis = {
+  intent_label: IntentLabel
+  intent_summary: string
+  persona: string
+  article_direction: string
+  user_needs: string[]
+  solution: string
+  notes?: string
+}
+
 export default function ToolsArticle() {
   const CMS_BASE = useCMSBase()
   const ADMIN_TOKEN = (import.meta as any).env?.VITE_ADMIN_TOKEN || ''
@@ -44,6 +56,8 @@ export default function ToolsArticle() {
   const [selected, setSelected] = React.useState<Record<string, boolean>>({})
   const [manualUrls, setManualUrls] = React.useState<string>('')
   const [manualMode, setManualMode] = React.useState<boolean>(false)
+  const [analysis, setAnalysis] = React.useState<SerpAnalysis|null>(null)
+  const [analysisLoading, setAnalysisLoading] = React.useState(false)
 
   // Sakura 直下の /api を優先して呼ぶため、管理トークン前提のブロックは外す
   const canCall = true
@@ -87,6 +101,69 @@ export default function ToolsArticle() {
 
   const provider = modelProvider === 'gemini' ? 'gemini' : 'openai'
 
+  const selectedSources = React.useMemo(() => sources.filter((s) => selected[s.url]), [sources, selected])
+
+  const sanitizeAnalysis = React.useCallback((data: any): SerpAnalysis => {
+    const allowed: IntentLabel[] = ['Do', 'Know', 'Buy', 'Go']
+    const clamp = (value: any, max: number) => {
+      const str = typeof value === 'string' ? value.trim() : ''
+      if (!str) return ''
+      return str.length > max ? str.slice(0, max) : str
+    }
+    const intentLabelRaw = typeof data?.intent_label === 'string' ? data.intent_label.trim() : ''
+    const intent_label = (allowed.includes(intentLabelRaw as IntentLabel) ? intentLabelRaw : 'Know') as IntentLabel
+    const needs = Array.isArray(data?.user_needs)
+      ? data.user_needs.map((item: any) => clamp(item, 120)).filter(Boolean)
+      : []
+    const keywordText = keyword.trim()
+    const defaultPersona = keywordText ? `${keywordText}に関心のある人` : 'このテーマに関心のある人'
+    const defaultNeed = keywordText ? `${keywordText}の基本や活用方法を知りたい` : 'テーマの基本を理解したい'
+    const defaultSolution = keywordText
+      ? `${keywordText}に関する主要な疑問へ体系的に答えるコンテンツを用意する`
+      : '主要な疑問に順番に答える構成にする'
+    const defaultDirection = '検索ユーザーの疑問を序盤から順番に解消する構成にする'
+    return {
+      intent_label,
+      intent_summary: clamp(data?.intent_summary, 200),
+      persona: clamp(data?.persona, 120) || defaultPersona,
+      article_direction: clamp(data?.article_direction, 200) || defaultDirection,
+      user_needs: needs.length ? needs : [defaultNeed],
+      solution: clamp(data?.solution, 220) || defaultSolution,
+      notes: clamp(data?.notes, 220) || undefined,
+    }
+  }, [keyword])
+
+  const runSerpAnalysis = React.useCallback(async (force = false) => {
+    if (!canCall) return
+    if (!keyword.trim()) return
+    if (!selectedSources.length) return
+    if (analysis && !force) return
+    setAnalysisLoading(true)
+    try {
+      const payload = { provider, model: modelId, keyword, sources: selectedSources }
+      let res: any = null
+      try {
+        res = await callPhp('/analyze-serp', payload)
+      } catch (err) {
+        res = await callCms('/analyze-serp', payload)
+      }
+      if (!res?.ok || !res?.analysis) throw new Error('AI分析の取得に失敗しました')
+      setAnalysis(sanitizeAnalysis(res.analysis))
+    } catch (e: any) {
+      setError(e?.message || 'AI分析の生成に失敗しました')
+    } finally {
+      setAnalysisLoading(false)
+    }
+  }, [analysis, canCall, callCms, callPhp, keyword, modelId, provider, sanitizeAnalysis, selectedSources, setError])
+
+  React.useEffect(() => {
+    if (!sources.length) return
+    if (!selectedSources.length) return
+    if (analysis || analysisLoading) return
+    if (!keyword.trim()) return
+    runSerpAnalysis(false)
+  }, [analysis, analysisLoading, keyword, runSerpAnalysis, selectedSources, sources.length])
+
   const sanitizeOutline = React.useCallback(
     (data: Outline): Outline => {
       const slugify = (str: string) =>
@@ -99,6 +176,11 @@ export default function ToolsArticle() {
           .replace(/^-+|-+$/g, '') || 'article'
 
       const title = (data.title || '').trim()
+      const persona = typeof data.persona === 'string' ? data.persona.trim() : ''
+      const targetAudience = typeof data.target_audience === 'string' ? data.target_audience.trim() : ''
+      const tone = typeof data.tone === 'string' ? data.tone.trim() : ''
+      const wcNumber = Number(data.word_count_target)
+      const wordCount = Number.isFinite(wcNumber) && wcNumber > 0 ? Math.round(wcNumber) : undefined
       const cleanH2 = (data.h2 || []).reduce<Outline['h2']>((acc, section) => {
         const h2Title = (section.title || '').trim()
         if (!h2Title) return acc
@@ -112,6 +194,10 @@ export default function ToolsArticle() {
         title: title || data.title || 'アウトライン',
         slug: (data.slug || slugify(title || data.slug || data.title || 'article')) as string,
         keyword: data.keyword || keyword,
+        persona,
+        target_audience: targetAudience,
+        tone,
+        word_count_target: wordCount,
         h2: cleanH2,
       }
     },
@@ -120,6 +206,22 @@ export default function ToolsArticle() {
 
   const handleOutlineTitleChange = React.useCallback((value: string) => {
     setOutline(prev => prev ? { ...prev, title: value } : prev)
+  }, [])
+
+  const handleOutlineMetaChange = React.useCallback((key: 'persona' | 'target_audience' | 'tone', value: string) => {
+    setOutline(prev => {
+      if (!prev) return prev
+      return { ...prev, [key]: value } as Outline
+    })
+  }, [])
+
+  const handleOutlineWordCountChange = React.useCallback((value: string) => {
+    setOutline(prev => {
+      if (!prev) return prev
+      const num = parseInt(value, 10)
+      const next = Number.isFinite(num) && num > 0 ? num : undefined
+      return { ...prev, word_count_target: next }
+    })
   }, [])
 
   const handleH2TitleChange = React.useCallback((index: number, value: string) => {
@@ -183,6 +285,7 @@ export default function ToolsArticle() {
         const initSel: Record<string, boolean> = {}
         for (const it of list) initSel[it.url] = true
         setSelected(initSel)
+        setAnalysis(null)
       } catch (e:any) {
         setError(e?.message || '検索に失敗しました')
       } finally { setLoading(false) }
@@ -192,7 +295,18 @@ export default function ToolsArticle() {
     setLoading(true)
     try {
       const chosen = sources.filter(s => selected[s.url])
-      const payload = { provider, model: modelId, keyword, sources: chosen }
+      const analysisPayload = analysis
+        ? {
+            intent_label: analysis.intent_label,
+            intent_summary: analysis.intent_summary.trim(),
+            persona: analysis.persona.trim(),
+            article_direction: analysis.article_direction.trim(),
+            user_needs: analysis.user_needs.map((item) => item.trim()).filter(Boolean),
+            solution: analysis.solution.trim(),
+            ...(analysis.notes ? { notes: analysis.notes.trim() } : {}),
+          }
+        : null
+      const payload = { provider, model: modelId, keyword, sources: chosen, ...(analysisPayload ? { analysis: analysisPayload } : {}) }
       let res: any = null
       try { res = await callPhp('/generate-outline', payload) } catch { res = await callCms('/generate-outline', payload) }
       if (!res?.ok || !res?.outline) throw new Error('Invalid response')
@@ -335,6 +449,7 @@ export default function ToolsArticle() {
                   const initSel: Record<string, boolean> = {}
                   for (const it of out) initSel[it.url] = true
                   setSelected(initSel)
+                  setAnalysis(null)
                   setManualMode(false)
                 } catch (e:any) {
                   setError(e?.message || '抽出に失敗しました')
@@ -381,10 +496,105 @@ export default function ToolsArticle() {
                 ))}
               </div>
               <div className="mt-3 flex gap-2">
-                <button disabled={loading||!canCall} onClick={()=>{ setSources([]); setSelected({}); setOutline(null); }} className="px-3 py-1 border rounded">検索をやり直す</button>
+                  <button disabled={loading||!canCall} onClick={()=>{ setSources([]); setSelected({}); setOutline(null); setAnalysis(null); }} className="px-3 py-1 border rounded">検索をやり直す</button>
                   <button disabled={loading || !keyword.trim() || !canCall} onClick={onGenerateOutline} className="px-3 py-1 rounded bg-primary text-primary-foreground disabled:opacity-50">選んだサイトを参考に構成案を作成</button>
                 <button disabled={loading} onClick={()=> setManualMode(true)} className="px-3 py-1 border rounded">URLを手動入力</button>
               </div>
+            </div>
+          )}
+
+          {(sources.length > 0 || analysis) && (
+            <div className="p-4 border rounded bg-card space-y-3">
+              <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+                <div>
+                  <div className="font-semibold">検索意図・ニーズ分析</div>
+                  <p className="text-xs text-muted-foreground">検索結果をもとにAIが意図・ペルソナ・ニーズを整理します。必要に応じて編集してください。</p>
+                </div>
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    disabled={analysisLoading || !selectedSources.length || loading}
+                    onClick={()=>{ setAnalysis(null); runSerpAnalysis(true) }}
+                    className="px-3 py-1 border rounded disabled:opacity-50"
+                  >
+                    {analysis ? 'AI分析を再生成' : 'AI分析を生成'}
+                  </button>
+                </div>
+              </div>
+              {analysisLoading && !analysis && (
+                <div className="text-sm text-muted-foreground">AIが分析中です…</div>
+              )}
+              {analysis && (
+                <div className="grid gap-3">
+                  <div className="grid gap-1">
+                    <label className="text-xs text-muted-foreground">検索意図</label>
+                    <div className="grid gap-2 sm:grid-cols-[140px,1fr] sm:items-center">
+                      <select
+                        className="border rounded px-2 py-1"
+                        value={analysis.intent_label}
+                        onChange={(e)=>{
+                          const value = e.target.value as IntentLabel
+                          setAnalysis(prev => prev ? { ...prev, intent_label: value } : prev)
+                        }}
+                      >
+                        <option value="Know">Know（情報収集）</option>
+                        <option value="Do">Do（課題解決・実行）</option>
+                        <option value="Buy">Buy（比較・購入検討）</option>
+                        <option value="Go">Go（場所・サービス指名）</option>
+                      </select>
+                      <textarea
+                        className="border rounded px-2 py-1 w-full h-16 resize-y"
+                        value={analysis.intent_summary}
+                        onChange={(e)=> setAnalysis(prev => prev ? { ...prev, intent_summary: e.target.value } : prev)}
+                      />
+                    </div>
+                  </div>
+                  <div className="grid gap-1">
+                    <label className="text-xs text-muted-foreground">想定ペルソナ</label>
+                    <input
+                      className="border rounded px-2 py-1"
+                      value={analysis.persona}
+                      onChange={(e)=> setAnalysis(prev => prev ? { ...prev, persona: e.target.value } : prev)}
+                    />
+                  </div>
+                  <div className="grid gap-1">
+                    <label className="text-xs text-muted-foreground">どのような方向性の記事にするか</label>
+                    <textarea
+                      className="border rounded px-2 py-1 h-20 resize-y"
+                      value={analysis.article_direction}
+                      onChange={(e)=> setAnalysis(prev => prev ? { ...prev, article_direction: e.target.value } : prev)}
+                    />
+                  </div>
+                  <div className="grid gap-1">
+                    <label className="text-xs text-muted-foreground">ユーザーの抱えているニーズ（1行につき1つ）</label>
+                    <textarea
+                      className="border rounded px-2 py-1 h-24 resize-y"
+                      value={analysis.user_needs.join('\n')}
+                      onChange={(e)=>{
+                        const lines = e.target.value.split(/\r?\n/).map(line => line.trim()).filter(Boolean)
+                        setAnalysis(prev => prev ? { ...prev, user_needs: lines } : prev)
+                      }}
+                    />
+                  </div>
+                  <div className="grid gap-1">
+                    <label className="text-xs text-muted-foreground">ニーズを解決するには</label>
+                    <textarea
+                      className="border rounded px-2 py-1 h-20 resize-y"
+                      value={analysis.solution}
+                      onChange={(e)=> setAnalysis(prev => prev ? { ...prev, solution: e.target.value } : prev)}
+                    />
+                  </div>
+                  <div className="grid gap-1">
+                    <label className="text-xs text-muted-foreground">メモ（任意）</label>
+                    <textarea
+                      className="border rounded px-2 py-1 h-16 resize-y"
+                      value={analysis.notes ?? ''}
+                      placeholder="補足したいポイントや注意書きがあれば入力"
+                      onChange={(e)=> setAnalysis(prev => prev ? { ...prev, notes: e.target.value } : prev)}
+                    />
+                  </div>
+                </div>
+              )}
             </div>
           )}
 
@@ -397,6 +607,45 @@ export default function ToolsArticle() {
                   value={outline.title || ''}
                   onChange={(e)=> handleOutlineTitleChange(e.target.value)}
                 />
+              </div>
+              <div className="grid gap-3 sm:grid-cols-2">
+                <label className="grid gap-1">
+                  <span className="text-xs text-muted-foreground">ペルソナ</span>
+                  <input
+                    className="border rounded px-2 py-1"
+                    value={outline.persona || ''}
+                    onChange={(e)=> handleOutlineMetaChange('persona', e.target.value)}
+                  />
+                </label>
+                <label className="grid gap-1">
+                  <span className="text-xs text-muted-foreground">想定読者</span>
+                  <input
+                    className="border rounded px-2 py-1"
+                    value={outline.target_audience || ''}
+                    onChange={(e)=> handleOutlineMetaChange('target_audience', e.target.value)}
+                  />
+                </label>
+              </div>
+              <div className="grid gap-3 sm:grid-cols-2">
+                <label className="grid gap-1">
+                  <span className="text-xs text-muted-foreground">トーン</span>
+                  <input
+                    className="border rounded px-2 py-1"
+                    value={outline.tone || ''}
+                    onChange={(e)=> handleOutlineMetaChange('tone', e.target.value)}
+                  />
+                </label>
+                <label className="grid gap-1">
+                  <span className="text-xs text-muted-foreground">目標文字数</span>
+                  <input
+                    type="number"
+                    min={0}
+                    className="border rounded px-2 py-1"
+                    value={outline.word_count_target ?? ''}
+                    onChange={(e)=> handleOutlineWordCountChange(e.target.value)}
+                    placeholder="例：1800"
+                  />
+                </label>
               </div>
               <div className="space-y-3">
                 {outline.h2.map((section, index) => (


### PR DESCRIPTION
## Summary
- make the SERP intent analysis fallbacks derive persona, needs, solutions, and direction from the current keyword instead of hard-coded marketing defaults
- update outline normalization, defaults, and article prompts to use neutral tone/audience language and a generic fallback outline structure
- mirror the neutral defaults on the media tool page so edited analyses start from keyword-aware copy

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca05fc97d0832eb23ba465702eca5e