### PR TITLE
Add sanitized SERP analysis to article generation payload

### DIFF
--- a/src/tools/ToolsArticle.tsx
+++ b/src/tools/ToolsArticle.tsx
@@ -38,6 +38,15 @@ type SerpAnalysis = {
   notes?: string
 }
 
+type GenerateArticlePayload = {
+  provider: 'gemini' | 'openai'
+  model: string
+  outline: Outline
+  analysis?: SerpAnalysis
+}
+
+type JsonBody = Record<string, unknown>
+
 export default function ToolsArticle() {
   const CMS_BASE = useCMSBase()
   const ADMIN_TOKEN = (import.meta as any).env?.VITE_ADMIN_TOKEN || ''
@@ -62,7 +71,7 @@ export default function ToolsArticle() {
   // Sakura 直下の /api を優先して呼ぶため、管理トークン前提のブロックは外す
   const canCall = true
 
-  async function callCms(path: string, body: any) {
+  async function callCms(path: string, body: JsonBody) {
     const url = CMS_BASE + path
     const r = await fetch(url, {
       method: 'POST',
@@ -77,12 +86,12 @@ export default function ToolsArticle() {
     try { return JSON.parse(text) } catch { return null }
   }
 
-  async function callPhp(path: string, body: any) {
+  async function callPhp(path: string, body: JsonBody) {
     // Absolute root /api so it works from both / and /media/
     const url = `/api${path}.php`
     // WAFに弾かれにくい x-www-form-urlencoded で送信
     const params = new URLSearchParams()
-    for (const [k, v] of Object.entries(body || {})) {
+    for (const [k, v] of Object.entries(body)) {
       if (v && typeof v === 'object') {
         params.append(k, JSON.stringify(v))
       } else if (v !== undefined && v !== null) {
@@ -339,11 +348,10 @@ export default function ToolsArticle() {
     setOutline(sanitizedOutline)
     setError(''); setLoading(true); setArticleHtml('')
     try {
-      const payload = {
-        provider,
-        model: modelId,
-        outline: sanitizedOutline,
-      }
+      const sanitizedAnalysis = analysis ? sanitizeAnalysis(analysis) : null
+      const payload: GenerateArticlePayload = sanitizedAnalysis
+        ? { provider, model: modelId, outline: sanitizedOutline, analysis: sanitizedAnalysis }
+        : { provider, model: modelId, outline: sanitizedOutline }
       let res: any = null
       try {
         res = await callPhp('/generate-article', payload)


### PR DESCRIPTION
## Summary
- reuse the existing sanitizeAnalysis logic before sending SERP analysis with article generation requests
- add the optional analysis field to the generate-article payload typing and shared request helpers
- keep the article generation flow unchanged when analysis data is not available

## Testing
- npm run build:tools *(fails: Rollup cannot resolve "react-router-dom" from src/tools/main.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68caefc1e7ec832ea791fed4fed7c701