### PR TITLE
Remove hero CTAs from hero section

### DIFF
--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -141,36 +141,9 @@ export function HeroSection() {
           initial={{ opacity: 0, y: 30 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.8, delay: 1.2 }}
-          className="text-lg md:text-xl lg:text-2xl text-gray-600 mb-16 max-w-3xl mx-auto font-light tracking-wide leading-relaxed"
+          className="text-lg md:text-xl lg:text-2xl text-gray-600 mb-0 max-w-3xl mx-auto font-light tracking-wide leading-relaxed"
         >
           マーケティングの課題を、AIで解決し確かな成果に。
-        </motion.p>
-
-        {/* CTAs */}
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.6, delay: 1.35 }}
-          className="flex items-center justify-center gap-4 mb-6"
-        >
-          <a href="#contact" aria-label="無料相談へ"
-             className="px-6 py-3 bg-black text-white font-bold tracking-wide hover:bg-red-500 transition-colors">
-            無料相談
-          </a>
-          <a href="#media" aria-label="事例・最新情報を見る"
-             className="px-6 py-3 border border-black text-black font-bold tracking-wide hover:bg-black hover:text-white transition-colors">
-            事例を見る
-          </a>
-        </motion.div>
-
-        {/* Social proof */}
-        <motion.p
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 0.8 }}
-          transition={{ duration: 0.6, delay: 1.55 }}
-          className="text-sm md:text-base text-gray-500 mb-12"
-        >
-          導入50社以上・年間記事制作1200本・平均CPA<span className="mx-1">32%</span>改善
         </motion.p>
       </motion.div>
 


### PR DESCRIPTION
## Summary
- remove the hero CTA button block and social proof copy
- tighten subtitle spacing to avoid extra gap after the CTA removal

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cb51b220b8832e8c4e65f21e229984