### PR TITLE
Remove free consultation CTA from navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,8 +59,9 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "./node_modules/.bin/vite build && npm run build:tools && node scripts/prerender.mjs",
-    "build:tools": "./node_modules/.bin/vite build --config tools/vite.config.ts",
+    "ensure:media": "node scripts/ensure-media-deps.cjs",
+    "build": "npm run ensure:media && ./node_modules/.bin/vite build && ./node_modules/.bin/vite build --config tools/vite.config.ts && node scripts/prerender.mjs",
+    "build:tools": "npm run ensure:media && ./node_modules/.bin/vite build --config tools/vite.config.ts",
     "postbuild": "cd media && npm ci && ../node_modules/.bin/vite build && node scripts/prerender.mjs"
   }
 }

--- a/scripts/ensure-media-deps.cjs
+++ b/scripts/ensure-media-deps.cjs
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+const { existsSync } = require('fs')
+const { spawnSync } = require('child_process')
+const path = require('path')
+
+const rootDir = path.resolve(__dirname, '..')
+const mediaDir = path.join(rootDir, 'media')
+const tailwindPackage = path.join(mediaDir, 'node_modules', 'tailwindcss', 'package.json')
+
+if (!existsSync(tailwindPackage)) {
+  const result = spawnSync('npm', ['ci'], {
+    cwd: mediaDir,
+    stdio: 'inherit',
+  })
+
+  if (result.status !== 0) {
+    process.exit(result.status || 1)
+  }
+}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -74,16 +74,6 @@ export function Navigation() {
                 />
               </motion.a>
             ))}
-            {/* Header CTA */}
-            <motion.a
-              href="#contact"
-              whileHover={{ scale: 1.05 }}
-              whileTap={{ scale: 0.98 }}
-              className="inline-flex items-center justify-center px-4 py-2 bg-black text-white text-sm font-bold tracking-wide hover:bg-red-500 transition-colors"
-              aria-label="無料相談はこちら"
-            >
-              無料相談
-            </motion.a>
           </div>
 
           {/* Mobile Menu Button */}
@@ -125,17 +115,6 @@ export function Navigation() {
                   {item.name}
                 </motion.a>
               ))}
-              <motion.a
-                href="#contact"
-                initial={{ opacity: 0, x: -20 }}
-                animate={{ opacity: 1, x: 0 }}
-                transition={{ delay: navItems.length * 0.1 }}
-                onClick={() => setIsMobileMenuOpen(false)}
-                className="inline-flex items-center justify-center w-full px-4 py-3 bg-black text-white font-bold tracking-wide hover:bg-red-500 transition-colors"
-                aria-label="無料相談はこちら"
-              >
-                無料相談
-              </motion.a>
             </div>
           </motion.div>
         )}


### PR DESCRIPTION
## Summary
- remove the "無料相談" call-to-action button from the desktop navigation
- remove the matching "無料相談" entry from the mobile menu
- ensure the tools build step installs the media Tailwind dependency before bundling so the CI build no longer fails

## Testing
- npm run build:tools
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb51b31b84832e8a0b6afe9fcdf24b