### PR TITLE
Remove free consultation wording from contact CTA

### DIFF
--- a/src/components/ContactSection.tsx
+++ b/src/components/ContactSection.tsx
@@ -324,7 +324,7 @@ export function ContactSection() {
                         whileHover={{ x: submissionStatus !== 'submitting' ? 5 : 0 }}
                         transition={{ type: "spring", stiffness: 400, damping: 25 }}
                       >
-                        {submissionStatus === 'submitting' ? '送信中...' : '無料で相談する（24h以内に返信）'}
+                        {submissionStatus === 'submitting' ? '送信中...' : '送信する（24時間以内に返信）'}
                         {submissionStatus !== 'submitting' && (
                           <motion.div
                             whileHover={{ rotate: 45, scale: 1.2 }}


### PR DESCRIPTION
## Summary
- remove the "無料相談" phrasing from the contact form submit button so the CTA no longer advertises free consultation

## Testing
- `npm run build` *(fails: tailwindcss requires an `@tailwind base` directive when `@layer base` is used in src/tools/styles.css)*

------
https://chatgpt.com/codex/tasks/task_e_68cb57db1ad8832ea407a99c82a493fb